### PR TITLE
Add multilingual support

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -7,6 +7,8 @@ import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import LanguageSelector from '@/components/LanguageSelector';
+import i18n from '@/i18n';
 
 export default function TabTwoScreen() {
   return (
@@ -20,10 +22,11 @@ export default function TabTwoScreen() {
           style={styles.headerImage}
         />
       }>
+      <LanguageSelector />
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Explore</ThemedText>
+        <ThemedText type="title">{i18n.t('explore.title')}</ThemedText>
       </ThemedView>
-      <ThemedText>This app includes example code to help you get started.</ThemedText>
+      <ThemedText>{i18n.t('explore.description')}</ThemedText>
       <Collapsible title="File-based routing">
         <ThemedText>
           This app has two screens:{' '}
@@ -35,7 +38,7 @@ export default function TabTwoScreen() {
           sets up the tab navigator.
         </ThemedText>
         <ExternalLink href="https://docs.expo.dev/router/introduction">
-          <ThemedText type="link">Learn more</ThemedText>
+          <ThemedText type="link">{i18n.t('explore.learnMore')}</ThemedText>
         </ExternalLink>
       </Collapsible>
       <Collapsible title="Android, iOS, and web support">
@@ -52,7 +55,7 @@ export default function TabTwoScreen() {
         </ThemedText>
         <Image source={require('@/assets/images/react-logo.png')} style={{ alignSelf: 'center' }} />
         <ExternalLink href="https://reactnative.dev/docs/images">
-          <ThemedText type="link">Learn more</ThemedText>
+          <ThemedText type="link">{i18n.t('explore.learnMore')}</ThemedText>
         </ExternalLink>
       </Collapsible>
       <Collapsible title="Custom fonts">
@@ -63,7 +66,7 @@ export default function TabTwoScreen() {
           </ThemedText>
         </ThemedText>
         <ExternalLink href="https://docs.expo.dev/versions/latest/sdk/font">
-          <ThemedText type="link">Learn more</ThemedText>
+          <ThemedText type="link">{i18n.t('explore.learnMore')}</ThemedText>
         </ExternalLink>
       </Collapsible>
       <Collapsible title="Light and dark mode components">
@@ -73,7 +76,7 @@ export default function TabTwoScreen() {
           what the user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
         </ThemedText>
         <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-          <ThemedText type="link">Learn more</ThemedText>
+          <ThemedText type="link">{i18n.t('explore.learnMore')}</ThemedText>
         </ExternalLink>
       </Collapsible>
       <Collapsible title="Animations">

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,12 +1,21 @@
 import { Image } from 'expo-image';
 import { Platform, StyleSheet } from 'react-native';
 
+import LanguageSelector from '@/components/LanguageSelector';
+import i18n from '@/i18n';
+
 import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 
 export default function HomeScreen() {
+  const shortcut = Platform.select({
+    ios: 'cmd + d',
+    android: 'cmd + m',
+    web: 'F12',
+  });
+
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
@@ -16,40 +25,25 @@ export default function HomeScreen() {
           style={styles.reactLogo}
         />
       }>
+      <LanguageSelector />
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
+        <ThemedText type="title">{i18n.t('home.welcome')}</ThemedText>
         <HelloWave />
       </ThemedView>
       <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
+        <ThemedText type="subtitle">{i18n.t('home.step1Title')}</ThemedText>
         <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
+          {i18n.t('home.step1Description')} <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText>.{' '}
+          {i18n.t('home.openDevtools', { shortcut })}
         </ThemedText>
       </ThemedView>
       <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
+        <ThemedText type="subtitle">{i18n.t('home.step2Title')}</ThemedText>
+        <ThemedText>{i18n.t('home.step2Description')}</ThemedText>
       </ThemedView>
       <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
+        <ThemedText type="subtitle">{i18n.t('home.step3Title')}</ThemedText>
+        <ThemedText>{i18n.t('home.step3Description')}</ThemedText>
       </ThemedView>
     </ParallaxScrollView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { LanguageProvider } from '@/context/LanguageContext';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -18,12 +19,14 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <LanguageProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </LanguageProvider>
   );
 }

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View, Button } from 'react-native';
+import { useLanguage } from '@/context/LanguageContext';
+import i18n from '@/i18n';
+
+export default function LanguageSelector() {
+  const { language, setLanguage } = useLanguage();
+  return (
+    <View style={{ flexDirection: 'row', gap: 8, marginBottom: 8 }}>
+      <Button
+        title={i18n.t('language.fr')}
+        onPress={() => setLanguage('fr')}
+        color={language === 'fr' ? '#888' : undefined}
+      />
+      <Button
+        title={i18n.t('language.en')}
+        onPress={() => setLanguage('en')}
+        color={language === 'en' ? '#888' : undefined}
+      />
+    </View>
+  );
+}

--- a/context/LanguageContext.tsx
+++ b/context/LanguageContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import i18n, { Language } from '@/i18n';
+
+interface LanguageContextProps {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export function LanguageProvider({ children }: React.PropsWithChildren<{}>) {
+  const defaultLang = (i18n.locale.split('-')[0] as Language) === 'fr' ? 'fr' : 'en';
+  const [language, setLanguageState] = useState<Language>(defaultLang);
+
+  useEffect(() => {
+    i18n.locale = language;
+  }, [language]);
+
+  const setLanguage = (lang: Language) => {
+    setLanguageState(lang);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used within LanguageProvider');
+  return ctx;
+}

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,0 +1,56 @@
+import { I18n } from 'i18n-js';
+import * as Localization from 'expo-localization';
+
+export const translations = {
+  en: {
+    home: {
+      welcome: 'Welcome!',
+      step1Title: 'Step 1: Try it',
+      step1Description: 'Edit app/(tabs)/index.tsx to see changes.',
+      openDevtools: 'Press {shortcut} to open developer tools.',
+      step2Title: 'Step 2: Explore',
+      step2Description: "Tap the Explore tab to learn more about what's included in this starter app.",
+      step3Title: 'Step 3: Get a fresh start',
+      step3Description: 'When you\'re ready, run npm run reset-project to get a fresh app directory.',
+    },
+    explore: {
+      title: 'Explore',
+      description: 'This app includes example code to help you get started.',
+      learnMore: 'Learn more',
+    },
+    language: {
+      fr: 'Français',
+      en: 'English',
+    },
+  },
+  fr: {
+    home: {
+      welcome: 'Bienvenue\u00A0!',
+      step1Title: '\u00C9tape\u00A01\u00A0: Essayez',
+      step1Description: 'Modifiez app/(tabs)/index.tsx pour voir les changements.',
+      openDevtools: 'Appuyez sur {shortcut} pour ouvrir les outils d\u00E9veloppeur.',
+      step2Title: '\u00C9tape\u00A02\u00A0: Explorer',
+      step2Description: "Touchez l'onglet Explorer pour en savoir plus sur le contenu de cette application de d\u00E9part.",
+      step3Title: '\u00C9tape\u00A03\u00A0: Repartir de z\u00E9ro',
+      step3Description: "Quand vous \u00EAtes pr\u00EAt, ex\u00E9cutez npm run reset-project pour obtenir un nouveau dossier app.",
+    },
+    explore: {
+      title: 'Explorer',
+      description: "Cette appli inclut du code d'exemple pour vous aider \u00E0 d\u00E9marrer.",
+      learnMore: 'En savoir plus',
+    },
+    language: {
+      fr: 'Français',
+      en: 'Anglais',
+    },
+  },
+};
+
+const i18n = new I18n(translations);
+
+i18n.enableFallback = true;
+i18n.locale = Localization.locale;
+
+export type Language = keyof typeof translations;
+
+export default i18n;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,14 @@
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.3.1",
         "expo-linking": "~7.1.6",
+        "expo-localization": "^16.1.6",
         "expo-router": "~5.1.2",
         "expo-splash-screen": "~0.30.9",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.9",
         "expo-web-browser": "~14.2.0",
+        "i18n-js": "^4.5.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.4",
@@ -4536,6 +4538,15 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -6313,6 +6324,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-16.1.6.tgz",
+      "integrity": "sha512-v4HwNzs8QvyKHwl40MvETNEKr77v1o9/eVC8WCBY++DIlBAvonHyJe2R9CfqpZbC4Tlpl7XV+07nLXc8O5PQsA==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.13.tgz",
@@ -7222,6 +7246,17 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/i18n-js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/i18n-js/-/i18n-js-4.5.1.tgz",
+      "integrity": "sha512-n7jojFj1WC0tztgr0I8jqTXuIlY1xNzXnC3mjKX/YjJhimdM+jXM8vOmn9d3xQFNC6qDHJ4ovhdrGXrRXLIGkA==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "*",
+        "lodash": "*",
+        "make-plural": "*"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -8497,6 +8532,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8619,6 +8660,12 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/make-plural": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
+      "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg==",
+      "license": "Unicode-DFS-2016"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -10702,6 +10749,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.1",
     "expo-linking": "~7.1.6",
+    "expo-localization": "^16.1.6",
     "expo-router": "~5.1.2",
     "expo-splash-screen": "~0.30.9",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.9",
     "expo-web-browser": "~14.2.0",
+    "i18n-js": "^4.5.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.4",
@@ -41,9 +43,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "typescript": "~5.8.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- include i18n with English and French strings
- add LanguageProvider and selection component
- localize home and explore pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68656ee9fe648332b10e2e1a86a5fd7f